### PR TITLE
Atualização da função da animação 2

### DIFF
--- a/pio_matrix.c
+++ b/pio_matrix.c
@@ -323,7 +323,7 @@ void animacao_2(uint32_t led_bin, PIO pio, uint sm){
          0.0, 0.0, 0.5, 0.0, 0.0}
     };
 
-    for (int frame = 0; frame < 15; frame+3) {  // Iteração de frames
+    for (int frame = 0; frame < 15; frame += 3) {  // Iteração de frames
         for (int16_t i = 0; i < NUM_PIXELS; i++) {    // Iteração de pixels
 
             led_bin = matrix_rgb(animacao[frame][24 - i], animacao[frame + 1][24 - i], animacao[frame + 2][24 - i]);


### PR DESCRIPTION
A incrementação do laço de repetição for que cuida dos frames estava errada. Anteriormente, havia "frame +3", porém o correto é frame +=3"